### PR TITLE
Updates how noether gets normal and origin

### DIFF
--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_variable_slicer_raster_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_variable_slicer_raster_planner.h
@@ -36,8 +36,17 @@ public:
 
   void setSearchRadius(const double search_radius);
   void setLineSpacing(std::vector<float> line_spacing);
+  void setDirectionVector(const Eigen::Vector3d& direction);
+  void setNormalVector(const Eigen::Vector3d& normal);
+  void setCutOrigin(const Eigen::Vector3d& origin);
   void setMinSegmentSize(const double min_segment_size);
   void generateRastersBidirectionally(const bool bidirectional);
+
+  Eigen::Vector3d cut_direction;
+
+  Eigen::Vector3d cut_normal;
+
+  Eigen::Vector3d cut_origin;
 
 protected:
   /**

--- a/noether_tpp/src/tool_path_planners/raster/plane_variable_slicer_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/plane_variable_slicer_raster_planner.cpp
@@ -477,18 +477,18 @@ ToolPaths PlaneVariableSlicerRasterPlanner::planImpl(const pcl::PolygonMesh& mes
     pcl::getMinMax3D(proj, min, max);
     Eigen::Array3f scales = max.getArray3fMap() - min.getArray3fMap();
 
+    std::cout << "SCALES: " << scales << std::endl;
     mesh_normal = pca.getEigenVectors().col(2).cast<double>().normalized();
     centroid = pca.getMean().head<3>().cast<double>();
     pca_vecs = (pca.getEigenVectors().array().rowwise() * scales.transpose()).cast<double>();
   }
 
   // Get the initial cutting plane
-  const Eigen::Vector3d cut_direction = dir_gen_->generate(mesh);
-  const Eigen::Vector3d cut_normal = (cut_direction.normalized().cross(mesh_normal)).normalized();
+  // const Eigen::Vector3d cut_normal = (cut_direction.normalized().cross(mesh_normal)).normalized();
 
 
   // Get the initial plane starting location
-  const Eigen::Vector3d cut_origin = origin_gen_->generate(mesh);
+  // const Eigen::Vector3d cut_origin = origin_gen_->generate(mesh);
 
   // std::vector<float> line_spacing_varied = {0.1, 0.5, 0.9, 0.3, 0.2};
   auto num_planes = static_cast<std::size_t>(line_spacing_varied.size());
@@ -663,6 +663,18 @@ ToolPathPlanner::ConstPtr PlaneVariableSlicerRasterPlannerFactory::create() cons
   return std::move(planner);
 }
 
+void PlaneVariableSlicerRasterPlanner::setDirectionVector(const Eigen::Vector3d& direction)
+{
+  cut_direction = (direction);
+}
+
+void PlaneVariableSlicerRasterPlanner::setNormalVector(const Eigen::Vector3d& normal)
+{
+  cut_normal = (normal);
+}
+
 void PlaneVariableSlicerRasterPlanner::setLineSpacing(std::vector<float> line_spacing) { line_spacing_varied = line_spacing; }
+
+void PlaneVariableSlicerRasterPlanner::setCutOrigin(const Eigen::Vector3d& origin) { cut_origin = origin; }
 
 }  // namespace noether


### PR DESCRIPTION
This PR goes with the one in [agile_paint](https://github.com/OSU-AIMS/012349-agile-paint/pull/40) to ensure that Noether is using the same start and direction vectors as the slicer used. This just provides the needed functions so that the service can pass in the required values.